### PR TITLE
Storing data on a local database when connection is missing

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstarteDbContext.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteDbContext.cs
@@ -25,8 +25,6 @@ namespace AstarteDeviceSDKCSharp.Data
 {
     public partial class AstarteDbContext : DbContext
     {
-        public DbSet<AstarteGenericPropertyEntry> AstarteGenericProperties
-         => Set<AstarteGenericPropertyEntry>();
         private readonly string _persistencyDir = string.Empty;
 
         public AstarteDbContext(string persistencyDir)
@@ -34,6 +32,11 @@ namespace AstarteDeviceSDKCSharp.Data
             _persistencyDir = persistencyDir;
         }
 
+        public DbSet<AstarteGenericPropertyEntry> AstarteGenericProperties
+        => Set<AstarteGenericPropertyEntry>();
+
+        public DbSet<AstarteFailedMessageEntry> AstarteFailedMessages
+         => Set<AstarteFailedMessageEntry>();
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
 
@@ -50,6 +53,8 @@ namespace AstarteDeviceSDKCSharp.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<AstarteGenericPropertyEntry>()
+            .HasKey(x => x.Id);
+            modelBuilder.Entity<AstarteFailedMessageEntry>()
             .HasKey(x => x.Id);
             base.OnModelCreating(modelBuilder);
         }

--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AstarteDeviceSDKCSharp.Data
+{
+    public class AstarteFailedMessageEntry : IAstarteFailedMessage
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        [Required]
+        public int Qos { get; set; }
+        [Required]
+        public byte[] Payload { get; set; }
+        [Required]
+        public string Topic { get; set; } = string.Empty;
+
+        [Column("absolute_expiry")]
+        [Required]
+        protected long absoluteExpiry;
+
+
+        public AstarteFailedMessageEntry(int qos, byte[] payload, string topic)
+        {
+            Qos = qos;
+            Payload = payload;
+            Topic = topic;
+            absoluteExpiry = 0;
+        }
+
+        public AstarteFailedMessageEntry(int qos, byte[] payload, string topic,
+        int relativeExpiry)
+        {
+            Qos = qos;
+            Payload = payload;
+            Topic = topic;
+            absoluteExpiry = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) + relativeExpiry;
+        }
+
+        public string GetTopic()
+        {
+            return Topic;
+        }
+
+        public byte[] GetPayload()
+        {
+            return Payload;
+        }
+
+        public int GetQos()
+        {
+            return Qos;
+        }
+
+        public bool IsExpired()
+        {
+            return absoluteExpiry > (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        }
+    }
+}

--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageStorage.cs
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+namespace AstarteDeviceSDKCSharp.Data
+{
+    public class AstarteFailedMessageStorage : IAstarteFailedMessageStorage
+    {
+        private readonly AstarteDbContext _astarteDbContext;
+
+        private static List<AstarteFailedMessageEntry> _astarteFailedMessageVolatile = new();
+
+        public AstarteFailedMessageStorage(string persistencyDir)
+        {
+            this._astarteDbContext = new AstarteDbContext(persistencyDir);
+        }
+
+        public void AckFirst()
+        {
+            var failedMessages = _astarteDbContext.AstarteFailedMessages
+            .OrderBy(x => x.Id)
+            .ToList();
+
+            if (failedMessages.Count() > 0)
+            {
+                _astarteDbContext.AstarteFailedMessages.Remove(failedMessages.First());
+            }
+
+            _astarteDbContext.SaveChanges();
+        }
+
+        public void InsertStored(string topic, byte[] payload, int qos)
+        {
+            AstarteFailedMessageEntry failedMessageEntry
+            = new AstarteFailedMessageEntry(qos, payload, topic);
+
+            _astarteDbContext.AstarteFailedMessages.Add(failedMessageEntry);
+
+            _astarteDbContext.SaveChanges();
+        }
+
+        public void InsertStored(string topic, byte[] payload, int qos, int relativeExpiry)
+        {
+            AstarteFailedMessageEntry failedMessageEntry
+            = new AstarteFailedMessageEntry(qos, payload, topic, relativeExpiry);
+
+            _astarteDbContext.AstarteFailedMessages.Add(failedMessageEntry);
+
+            _astarteDbContext.SaveChanges();
+        }
+
+        public void InsertVolatile(string topic, byte[] payload, int qos)
+        {
+            AstarteFailedMessageEntry failedMessageEntry
+            = new AstarteFailedMessageEntry(qos, payload, topic);
+
+            _astarteFailedMessageVolatile.Add(failedMessageEntry);
+        }
+
+        public void InsertVolatile(string topic, byte[] payload, int qos, int relativeExpiry)
+        {
+            AstarteFailedMessageEntry failedMessageEntry
+            = new AstarteFailedMessageEntry(qos, payload, topic, relativeExpiry);
+
+            _astarteFailedMessageVolatile.Add(failedMessageEntry);
+        }
+
+        public bool IsEmpty()
+        {
+            return !_astarteDbContext.AstarteFailedMessages.Any();
+        }
+
+        public AstarteFailedMessageEntry? PeekFirst()
+        {
+            return _astarteDbContext.AstarteFailedMessages
+            .OrderBy(x => x.Id)
+            .FirstOrDefault();
+        }
+
+        public void RejectFirst()
+        {
+            var failedMessages = _astarteDbContext.AstarteFailedMessages
+            .OrderBy(x => x.Id)
+            .ToList();
+
+            if (failedMessages.Count() > 0)
+            {
+                _astarteDbContext.AstarteFailedMessages.Remove(failedMessages.First());
+            }
+
+            _astarteDbContext.SaveChanges();
+        }
+    }
+}

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessage.cs
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+namespace AstarteDeviceSDKCSharp.Data
+{
+    public interface IAstarteFailedMessage
+    {
+        string GetTopic();
+
+        byte[] GetPayload();
+
+        int GetQos();
+
+        bool IsExpired();
+    }
+}

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Astarte.
+ *
+ * Copyright 2023 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+namespace AstarteDeviceSDKCSharp.Data
+{
+    public interface IAstarteFailedMessageStorage
+    {
+        void InsertVolatile(String topic, byte[] payload, int qos);
+
+        void InsertVolatile(String topic, byte[] payload, int qos, int relativeExpiry);
+
+        void InsertStored(String topic, byte[] payload, int qos);
+
+        void InsertStored(String topic, byte[] payload, int qos, int relativeExpiry);
+
+        bool IsEmpty();
+
+        AstarteFailedMessageEntry? PeekFirst();
+
+        void AckFirst();
+
+        void RejectFirst();
+    }
+}

--- a/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
+++ b/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
@@ -36,6 +36,7 @@ namespace AstarteDeviceSDKCSharp.Device
         private AstarteTransport? _astarteTransport;
         private IAstarteMessageListener? _astarteMessagelistener;
         private IAstartePropertyStorage astartePropertyStorage;
+        private AstarteFailedMessageStorage _astarteFailedMessageStorage;
         private bool _initialized;
         private const string _cryptoSubDir = "crypto";
         private bool _alwaysReconnect = false;
@@ -89,6 +90,7 @@ namespace AstarteDeviceSDKCSharp.Device
                 _context.Database.Migrate();
             }
 
+            _astarteFailedMessageStorage = new(fullCryptoDirPath);
         }
 
         private void Init()
@@ -112,6 +114,7 @@ namespace AstarteDeviceSDKCSharp.Device
         private void ConfigureTransport(AstarteTransport astarteTransport)
         {
             astarteTransport.SetDevice(this);
+            astarteTransport.SetFailedMessageStorage(_astarteFailedMessageStorage);
 
             if (_astarteTransport != null)
             {

--- a/AstarteDeviceSDKCSharp/Migrations/20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable.Designer.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstarteDeviceSDKCSharp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AstarteDeviceSDKCSharp.Migrations
 {
     [DbContext(typeof(AstarteDbContext))]
-    partial class AstarteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable")]
+    partial class AddAstarteFailedMessageAstarteFailedMessageEntryTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.13");

--- a/AstarteDeviceSDKCSharp/Migrations/20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable.Designer.cs.license
+++ b/AstarteDeviceSDKCSharp/Migrations/20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable.Designer.cs.license
@@ -1,0 +1,5 @@
+# This file is part of Astarte.
+#
+# Copyright 2023 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/AstarteDeviceSDKCSharp/Migrations/20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20230322082603_AddAstarteFailedMessageAstarteFailedMessageEntryTable.cs
@@ -1,0 +1,39 @@
+﻿// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// SPDX-License-Identifier: Apache-2.0
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AstarteDeviceSDKCSharp.Migrations
+{
+    public partial class AddAstarteFailedMessageAstarteFailedMessageEntryTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AstarteFailedMessages",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Qos = table.Column<int>(type: "INTEGER", nullable: false),
+                    Payload = table.Column<byte[]>(type: "BLOB", nullable: false),
+                    Topic = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AstarteFailedMessages", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AstarteFailedMessages");
+        }
+    }
+}

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceDatastreamMapping.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceDatastreamMapping.cs
@@ -27,7 +27,8 @@ namespace AstarteDeviceSDKCSharp.Protocol
     public class AstarteInterfaceDatastreamMapping : AstarteInterfaceMapping
     {
         private bool explicitTimestamp;
-        private MappingReliability reliability = MappingReliability.UNRELIABLE;
+        private MappingReliability reliability;
+        private MappingRetention retention;
         private int expiry;
 
         public enum MappingReliability
@@ -53,6 +54,11 @@ namespace AstarteDeviceSDKCSharp.Protocol
         public MappingReliability GetReliability()
         {
             return reliability;
+        }
+
+        public MappingRetention GetRetention()
+        {
+            return retention;
         }
 
         internal static AstarteInterfaceDatastreamMapping
@@ -81,6 +87,31 @@ namespace AstarteDeviceSDKCSharp.Protocol
                 {
                     astarteInterfaceDatastreamMapping.reliability = MappingReliability.UNIQUE;
                 }
+                else
+                {
+                    astarteInterfaceDatastreamMapping.reliability = MappingReliability.UNRELIABLE;
+                }
+
+            }
+
+            if (astarteMappingObject.Retention != null)
+            {
+                if (astarteMappingObject.Retention == "discard")
+                {
+                    astarteInterfaceDatastreamMapping.retention = MappingRetention.DISCARD;
+                }
+                else if (astarteMappingObject.Retention == "volatile")
+                {
+                    astarteInterfaceDatastreamMapping.retention = MappingRetention.VOLATILE;
+                }
+                else if (astarteMappingObject.Retention == "stored")
+                {
+                    astarteInterfaceDatastreamMapping.retention = MappingRetention.STORED;
+                }
+                else
+                {
+                    astarteInterfaceDatastreamMapping.retention = MappingRetention.DISCARD;
+                }
 
             }
 
@@ -96,6 +127,11 @@ namespace AstarteDeviceSDKCSharp.Protocol
         public bool IsExplicitTimestamp()
         {
             return explicitTimestamp;
+        }
+
+        public int GetExpiry()
+        {
+            return expiry;
         }
 
         public override void ValidatePayload(Object payload, DateTime? timestamp)

--- a/AstarteDeviceSDKCSharp/Transport/AstarteTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/AstarteTransport.cs
@@ -33,6 +33,7 @@ namespace AstarteDeviceSDKCSharp.Transport
         protected bool _introspectionSent = false;
         protected IAstarteMessageListener? _messageListener;
         protected IAstartePropertyStorage? _astartePropertyStorage;
+        protected IAstarteFailedMessageStorage? _failedMessageStorage;
         protected AstarteTransport(AstarteProtocolType type)
         {
             astarteProtocolType = type;
@@ -65,6 +66,17 @@ namespace AstarteDeviceSDKCSharp.Transport
         {
             _messageListener = messageListener;
         }
+
+        public IAstarteFailedMessageStorage? GetAstarteFailedMessageStorage()
+        {
+            return _failedMessageStorage;
+        }
+
+        public void SetFailedMessageStorage(IAstarteFailedMessageStorage failedMessageStorage)
+        {
+            _failedMessageStorage = failedMessageStorage;
+        }
+
         public IAstarteTransportEventListener? GetAstarteTransportEventListener()
         {
             return _astarteTransportEventListener;
@@ -78,6 +90,7 @@ namespace AstarteDeviceSDKCSharp.Transport
         public abstract Task Connect();
         public abstract void Disconnect();
         public abstract bool IsConnected();
+        public abstract void RetryFailedMessages();
 
         public void SetPropertyStorage(IAstartePropertyStorage propertyStorage)
         {

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
@@ -76,6 +76,15 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                 _introspectionSent = true;
             }
 
+            try
+            {
+                RetryFailedMessages();
+            }
+            catch (AstarteTransportException e)
+            {
+                throw new AstarteTransportException("Message redelivery failed", e);
+            }
+
             if (_astarteTransportEventListener != null)
             {
                 _astarteTransportEventListener.OnTransportConnected();


### PR DESCRIPTION
Storage data in cash memory or SQLite database.
Retention reading from AstarteInterfaceDatastreamMapping
VOLATILE - Storage data in cash memory
STORED - Storage data in SQLite database
DISCARD (default)

After successfully connecting to the MQTT broker send failed messages.

Closes: #4 