### PR TITLE
Ensure correct build of pairing Url

### DIFF
--- a/AstarteDeviceSDKCSharp.Tests/AstartePairingServiceTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/AstartePairingServiceTest.cs
@@ -235,5 +235,41 @@ namespace AstarteDeviceSDKCSharp.Tests
             Assert.Equal(expectedCredentialSecret, credentialSecret);
         }
 
+        [Fact]
+        public void TestPairingServiceUrlConstructor_Local()
+        {
+            // Arrange
+            Uri _expectedPairingUrl = new Uri("http://localhost:4003");
+
+            //Act
+            _service = new AstartePairingService(_expectedPairingUrl.OriginalString, "test");
+
+            Uri _actualPairingUrl = _service.PairingUrl();
+
+            //Assert
+            Assert.Equal(_expectedPairingUrl.Scheme, _actualPairingUrl.Scheme);
+            Assert.Equal(_expectedPairingUrl.Host, _actualPairingUrl.Host);
+            Assert.Equal(_expectedPairingUrl.Port, _actualPairingUrl.Port);
+            Assert.Equal("/v1", _actualPairingUrl.AbsolutePath);
+        }
+
+        [Fact]
+        public void TestPairingServiceUrlConstructor_Custom()
+        {
+            // Arrange
+            Uri _expectedPairingUrl = new Uri("https://astarte.instance.test/pairing");
+
+            //Act
+            _service = new AstartePairingService(_expectedPairingUrl.OriginalString, "test");
+
+            Uri _actualPairingUrl = _service.PairingUrl();
+
+            //Assert
+            Assert.Equal(_expectedPairingUrl.Scheme, _actualPairingUrl.Scheme);
+            Assert.Equal(_expectedPairingUrl.Host, _actualPairingUrl.Host);
+            Assert.Equal(_expectedPairingUrl.Port, _actualPairingUrl.Port);
+            Assert.Equal(_expectedPairingUrl.AbsolutePath + "/v1", _actualPairingUrl.AbsolutePath);
+        }
+
     }
 }

--- a/AstarteDeviceSDKCSharp/AstartePairingService.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingService.cs
@@ -43,12 +43,6 @@ namespace AstarteDeviceSDKCSharp
         {
             _astarteRealm = astarteRealm;
             _pairingUrl = new Uri($"{pairingUrl.TrimEnd('/')}/v1");
-
-            if (_pairingUrl == null)
-            {
-                throw new ArgumentNullException(nameof(_pairingUrl), "Pairing url is empty");
-            }
-
             _httpClient = new HttpClient();
 
         }

--- a/AstarteDeviceSDKCSharp/AstartePairingService.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingService.cs
@@ -42,14 +42,13 @@ namespace AstarteDeviceSDKCSharp
         public AstartePairingService(string pairingUrl, string astarteRealm)
         {
             _astarteRealm = astarteRealm;
-            _pairingUrl = new Uri(pairingUrl);
+            _pairingUrl = new Uri($"{pairingUrl.TrimEnd('/')}/v1");
 
             if (_pairingUrl == null)
             {
                 throw new ArgumentNullException(nameof(_pairingUrl), "Pairing url is empty");
             }
 
-            _pairingUrl = new Uri(_pairingUrl, "v1");
             _httpClient = new HttpClient();
 
         }

--- a/AstarteDeviceSDKCSharp/AstartePairingService.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingService.cs
@@ -374,5 +374,9 @@ namespace AstarteDeviceSDKCSharp
             return credentialSecret;
         }
 
+        public Uri PairingUrl()
+        {
+            return _pairingUrl;
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - Unreleased
+### Fixed
+- Fix the construction of Pairing URL.
+
 ## [0.5.0] - 2023-04-07
 ### Added
 - Initial Astarte Device C# SDK release.


### PR DESCRIPTION
Uri constructor removes the relative path if the user provides a pairing URL without "/" at the end. To avoid issue Uri constructor is removed. API version added on pairing URL string. The "TrimEnd" function is used to avoid double slashes in the URL. 

Closes: #10 