### PR TITLE
Fix misspelling in namespace

### DIFF
--- a/AstarteDeviceSDKCSharp.Tests/AstarteInterfaceMappingTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/AstarteInterfaceMappingTest.cs
@@ -19,7 +19,7 @@
  */
 
 using AstarteDeviceSDK.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using Newtonsoft.Json;
 using System;
 using Xunit;

--- a/AstarteDeviceSDKCSharp.Tests/Protocol/AstarteDeviceAggregateDatastreamInterfaceTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/Protocol/AstarteDeviceAggregateDatastreamInterfaceTest.cs
@@ -20,7 +20,7 @@
 
 using AstarteDeviceSDK.Protocol;
 using AstarteDeviceSDKCSharp.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/AstarteDeviceSDKCSharp.Tests/Protocol/AstarteDevicePropertyInterfaceTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/Protocol/AstarteDevicePropertyInterfaceTest.cs
@@ -20,7 +20,7 @@
 
 using AstarteDeviceSDK.Protocol;
 using AstarteDeviceSDKCSharp.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using System;
 using Xunit;
 

--- a/AstarteDeviceSDKCSharp.Tests/Protocol/AstarteInterfaceTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/Protocol/AstarteInterfaceTest.cs
@@ -19,7 +19,7 @@
  */
 
 using AstarteDeviceSDK.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using Xunit;
 
 namespace AstarteDeviceSDKCSharp.Tests

--- a/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
+++ b/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
@@ -23,7 +23,6 @@ using AstarteDeviceSDK.Protocol;
 using AstarteDeviceSDKCSharp.Crypto;
 using AstarteDeviceSDKCSharp.Data;
 using AstarteDeviceSDKCSharp.Protocol.AstarteException;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
 using AstarteDeviceSDKCSharp.Transport;
 using Microsoft.EntityFrameworkCore;
 

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteDeviceAggregateDatastreamInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteDeviceAggregateDatastreamInterface.cs
@@ -20,7 +20,7 @@
 
 using System.Diagnostics;
 using AstarteDeviceSDK.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using AstarteDeviceSDKCSharp.Transport;
 
 namespace AstarteDeviceSDKCSharp.Protocol

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInterfaceAlreadyPresentException.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInterfaceAlreadyPresentException.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-namespace AstarteDeviceSDKCSharp.Protocol.AstarteExeption
+namespace AstarteDeviceSDKCSharp.Protocol.AstarteException
 {
     public class AstarteInterfaceAlreadyPresentException : Exception
     {

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInterfaceMappingNotFoundException.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInterfaceMappingNotFoundException.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-namespace AstarteDeviceSDKCSharp.Protocol.AstarteExeption
+namespace AstarteDeviceSDKCSharp.Protocol.AstarteException
 {
     public class AstarteInterfaceMappingNotFoundException : Exception
     {

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInvalidInterfaceException.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInvalidInterfaceException.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-namespace AstarteDeviceSDKCSharp.Protocol.AstarteExeption
+namespace AstarteDeviceSDKCSharp.Protocol.AstarteException
 {
     public class AstarteInvalidInterfaceException : Exception
     {

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInvalidValueException.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteException/AstarteInvalidValueException.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-namespace AstarteDeviceSDKCSharp.Protocol.AstarteExeption
+namespace AstarteDeviceSDKCSharp.Protocol.AstarteException
 {
     public class AstarteInvalidValueException : Exception
     {

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterface.cs
@@ -21,7 +21,6 @@
 using AstarteDeviceSDKCSharp.Data;
 using AstarteDeviceSDKCSharp.Protocol;
 using AstarteDeviceSDKCSharp.Protocol.AstarteException;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
 using AstarteDeviceSDKCSharp.Transport;
 using Newtonsoft.Json;
 

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceDatastreamMapping.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceDatastreamMapping.cs
@@ -20,7 +20,7 @@
 
 using System.ComponentModel;
 using AstarteDeviceSDK.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 
 namespace AstarteDeviceSDKCSharp.Protocol
 {

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceMapping.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceMapping.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 
 namespace AstarteDeviceSDK.Protocol
 {

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
@@ -21,7 +21,7 @@
 using AstarteDeviceSDK.Protocol;
 using AstarteDeviceSDKCSharp.Device;
 using AstarteDeviceSDKCSharp.Protocol;
-using AstarteDeviceSDKCSharp.Protocol.AstarteExeption;
+using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using AstarteDeviceSDKCSharp.Utilities;
 using MQTTnet;
 using MQTTnet.Client;


### PR DESCRIPTION
Fix misspelling AstarteExeption to AstarteException

Closes: #17 