### PR TITLE
Fix properties sending in SendIndividualValue method

### DIFF
--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
@@ -44,6 +44,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
         string path, object? value, DateTime? timestamp)
         {
             AstarteInterfaceDatastreamMapping mapping;
+            int qos = 2;
 
             if (astarteInterface.GetType() == (typeof(AstarteDeviceDatastreamInterface)))
             {
@@ -57,13 +58,13 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                 {
                     throw new AstarteTransportException("Mapping not found", e);
                 }
-                int qos = QosFromReliability(mapping);
-
-                string topic = _baseTopic + "/" + astarteInterface.InterfaceName + path;
-                byte[] payload = AstartePayload.Serialize(value, timestamp);
-
-                await DoSendMqttMessage(topic, payload, qos);
+                qos = QosFromReliability(mapping);
             }
+
+            string topic = _baseTopic + "/" + astarteInterface.InterfaceName + path;
+            byte[] payload = AstartePayload.Serialize(value, timestamp);
+
+            await DoSendMqttMessage(topic, payload, qos);
         }
 
         private async Task DoSendMqttMessage(string topic, byte[] payload, int qos)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - Unreleased
+### Fixed
+- Fix a bug preventing sending of properties in the SendIndividualValue method.
+
 ## [0.5.1] - 2023-05-05
 ### Added
 - Add a global event listener for listening incoming data from Astarte.


### PR DESCRIPTION
This method now enables the transmission of individual values for the AstarteDeviceDatastreamInterface and has also been updated to support other interfaces, such as the AstarteDevicePropertyInterface.
Closes: #27 