### PR TITLE
Add enable/disable option to ignore SSL errors

### DIFF
--- a/AstarteDeviceSDKCSharp/Crypto/AstarteCryptoStore.cs
+++ b/AstarteDeviceSDKCSharp/Crypto/AstarteCryptoStore.cs
@@ -30,6 +30,7 @@ namespace AstarteDeviceSDKCSharp.Crypto
         private X509Certificate2? _certificate;
         private AstarteMutualTLSParametersFactory? _parametersFactory;
         private readonly string _cryptoStoreDir = string.Empty;
+        private bool _ignoreSSLErrors = false;
 
         public AstarteCryptoStore(string cryptoStoreDir)
         {
@@ -185,5 +186,12 @@ namespace AstarteDeviceSDKCSharp.Crypto
         {
             _certificate = astarteCertificate;
         }
+
+        public bool IgnoreSSLErrors
+        {
+            get { return _ignoreSSLErrors; }
+            set { _ignoreSSLErrors = value; }
+        }
+
     }
 }

--- a/AstarteDeviceSDKCSharp/Crypto/AstarteMutualTLSParametersFactory.cs
+++ b/AstarteDeviceSDKCSharp/Crypto/AstarteMutualTLSParametersFactory.cs
@@ -34,13 +34,13 @@ namespace AstarteDeviceSDKCSharp.Crypto
             {
                 UseTls = true,
                 Certificates = new List<X509Certificate?>
-                    {
-                      cryptoStore.GetCertificate()
-                    },
-                IgnoreCertificateChainErrors = true,
-                IgnoreCertificateRevocationErrors = true,
+                {
+                    cryptoStore.GetCertificate()
+                },
+                IgnoreCertificateChainErrors = cryptoStore.IgnoreSSLErrors,
+                IgnoreCertificateRevocationErrors = cryptoStore.IgnoreSSLErrors,
                 SslProtocol = System.Security.Authentication.SslProtocols.Tls12,
-                AllowUntrustedCertificates = true
+                AllowUntrustedCertificates = cryptoStore.IgnoreSSLErrors
             };
         }
 

--- a/AstarteDeviceSDKCSharp/Crypto/IAstarteCryptoStore.cs
+++ b/AstarteDeviceSDKCSharp/Crypto/IAstarteCryptoStore.cs
@@ -30,5 +30,6 @@ namespace AstarteDeviceSDKCSharp.Crypto
         void SetAstarteCertificate(X509Certificate2 astarteCertificate);
         string GenerateCSR(string commonName);
         MqttClientOptionsBuilderTlsParameters GetMqttClientOptionsBuilderTlsParameters();
+        bool IgnoreSSLErrors { get; set; }
     }
 }

--- a/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
+++ b/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
@@ -48,7 +48,8 @@ namespace AstarteDeviceSDKCSharp.Device
             string credentialSecret,
             IAstarteInterfaceProvider astarteInterfaceProvider,
             string pairingBaseUrl,
-            string cryptoStoreDirectory)
+            string cryptoStoreDirectory,
+            bool ignoreSSLErrors = false)
         {
             if (!Directory.Exists(cryptoStoreDirectory))
             {
@@ -61,12 +62,15 @@ namespace AstarteDeviceSDKCSharp.Device
                 Directory.CreateDirectory(fullCryptoDirPath);
             }
 
+            AstarteCryptoStore astarteCryptoStore = new AstarteCryptoStore(fullCryptoDirPath);
+            astarteCryptoStore.IgnoreSSLErrors = ignoreSSLErrors;
+
             _pairingHandler = new AstartePairingHandler(
              pairingBaseUrl,
              astarteRealm,
              deviceId,
              credentialSecret,
-             new AstarteCryptoStore(fullCryptoDirPath));
+             astarteCryptoStore);
 
             List<string> allInterfaces = astarteInterfaceProvider.LoadAllInterfaces();
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add the capability to update the introspection dynamically.
 - Handling sessionPresent flag from the broker.
+- Add option to ignore SSL errors in the AstarteDevice constructor.
 
 ## [0.5.3] - 2023-06-07
 ### Fixed


### PR DESCRIPTION
Add the "enable/disable" option to the AstarteDevice constructor to ignore SSL errors. It helps when using a self-signed certificate for the MQTT broker.