### PR TITLE
Fix aggregate payload mapping validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - Unreleased
+### Fixed
+- Fix payload validation on the aggregated object interface.
+
 ## [0.5.2] - 2023-05-26
 ### Fixed
 - Fix a bug preventing sending of properties in the SendIndividualValue method.


### PR DESCRIPTION
When validating the payload need to extract the parameter name and compare the payload against the mapping in the interface.