### PR TITLE
Fix bson to double array

### DIFF
--- a/AstarteDeviceSDKCSharp.Tests/Transport/AstarteMqttV1TransportTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/Transport/AstarteMqttV1TransportTest.cs
@@ -145,5 +145,18 @@ namespace AstarteDeviceSDKCSharp.Tests
             Assert.True(decodedMessage.GetPayload().GetType() == typeof(DateTime[]));
             Assert.Equal(d, decodedMessage.GetPayload());
         }
+
+        [Fact]
+        public void DoubleArrayToEncodedBSONTest()
+        {
+            double[] i = new double[] { 1.1, 2.1, 3.1 };
+            byte[] encodedPayload = AstartePayload.Serialize(i, new DateTime());
+            DecodedMessage decodedMessage = AstartePayload.Deserialize(encodedPayload);
+
+            var objects = decodedMessage.GetPayload() as object[];
+            double[] payloadArray = objects.Select(x => Convert.ToDouble(x)).ToArray();
+            Assert.True(payloadArray.GetType() == typeof(double[]));
+            Assert.Equal(i, (double[])payloadArray);
+        }
     }
 }

--- a/AstarteDeviceSDKCSharp/Utilities/AstartePayload.cs
+++ b/AstarteDeviceSDKCSharp/Utilities/AstartePayload.cs
@@ -145,14 +145,12 @@ namespace AstarteDeviceSDKCSharp.Utilities
 
                 return payload.GetType();
             }
-            else if (payload is JArray)
+            else if (payload is JArray bsonList)
             {
-                JArray bsonList = (JArray)payload;
-                var item = bsonList.First();
-                DateTime dateItem;
-                if (DateTime.TryParse(item.ToString(), out dateItem))
+                if (bsonList.First().Type is JTokenType.Date)
+                {
                     return typeof(DateTime[]);
-
+                }
                 return typeof(Array);
 
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.3] - Unreleased
 ### Fixed
 - Fix payload validation on the aggregated object interface.
+- Resolve the type inconsistency issue when deserializing BSON to a double array.
 
 ## [0.5.2] - 2023-05-26
 ### Fixed


### PR DESCRIPTION
Resolve the issue of type inconsistency when deserializing BSON to a double array.