### PR TITLE
Fix array equality check while publishing properties

### DIFF
--- a/AstarteDeviceSDKCSharp/Protocol/AstarteDevicePropertyInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteDevicePropertyInterface.cs
@@ -72,7 +72,7 @@ namespace AstarteDeviceSDKCSharp.Protocol
             }
             else
             {
-                if (!payload.Equals(storedValue.GetPayload()))
+                if (!storedValue.PayloadEquality(payload))
                 {
                     transport.SendIndividualValue(this, path, payload);
                 }

--- a/AstarteDeviceSDKCSharp/Utilities/DecodedMessage.cs
+++ b/AstarteDeviceSDKCSharp/Utilities/DecodedMessage.cs
@@ -54,6 +54,47 @@ namespace AstarteDeviceSDKCSharp.Utilities
         {
             this.timestamp = timestamp;
         }
+
+        public bool PayloadEquality(object? otherPayload)
+        {
+            if (otherPayload is null)
+            {
+                return false;
+            }
+
+            if (payload is Array array && otherPayload is Array otherArray)
+            {
+                if (array == null || otherArray == null) return false;
+                if (array.Length != otherArray.Length) return false;
+                return ArrayEquality(array, otherArray);
+            }
+
+            return payload.GetHashCode().Equals(otherPayload.GetHashCode());
+
+        }
+
+        private bool ArrayEquality(Array array, Array otherArray)
+        {
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                if (array.GetValue(i) == null || otherArray.GetValue(i) == null) return false;
+
+                if (array.GetValue(i) is Array arrayOfArray && otherArray.GetValue(i) is Array arrayOfOtherArray)
+                {
+                    if (!ArrayEquality(arrayOfArray, arrayOfOtherArray))
+                    {
+                        return false;
+                    }
+                }
+                else if (!array.GetValue(i)!.GetHashCode().Equals(otherArray.GetValue(i)!.GetHashCode()))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
     }
 
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix payload validation on the aggregated object interface.
 - Resolve the type inconsistency issue when deserializing BSON to a double array.
+- Resolve array equality issue when setting the device property.
 
 ## [0.5.2] - 2023-05-26
 ### Fixed


### PR DESCRIPTION
In C# "Equals" method compare arrays by reference. Instead of it, when the payload is "Array" we compare arrays by each element.