### PR TITLE
Validate endpoint parameter name for '/','+' and '#'

### DIFF
--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterface.cs
@@ -23,6 +23,7 @@ using AstarteDeviceSDKCSharp.Protocol;
 using AstarteDeviceSDKCSharp.Protocol.AstarteException;
 using AstarteDeviceSDKCSharp.Transport;
 using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 
 namespace AstarteDeviceSDK.Protocol
 {
@@ -220,6 +221,11 @@ namespace AstarteDeviceSDK.Protocol
                         matches = false;
                         break;
                     }
+                }
+                else if (mappingTokens[k].Contains("%{") && Regex.IsMatch(mappingTokens[k], "[/#\\+]"))
+                {
+                    matches = false;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Validate endpoint parameter names for '/','+', and '#'. 
If the user provides some of these characters mapping validation will fail.

Closes #20 