### PR TITLE
Fix the consistency of device properties in the local storage

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstartePropertyStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstartePropertyStorage.cs
@@ -137,10 +137,10 @@ namespace AstarteDeviceSDKCSharp.Data
                             && x.InterfaceMajor == interfaceMajor)
                             .FirstOrDefault();
 
+            byte[] bsonValue = AstartePayload.Serialize(value, null);
+
             if (astarteProp == null)
             {
-                byte[] bsonValue = AstartePayload.Serialize(value, null);
-
                 AstarteGenericPropertyEntry astarteProperty =
                     new AstarteGenericPropertyEntry
                     (interfaceName,
@@ -149,6 +149,10 @@ namespace AstarteDeviceSDKCSharp.Data
                     interfaceMajor);
 
                 _astarteDbContext.AstarteGenericProperties.Add(astarteProperty);
+            }
+            else
+            {
+                astarteProp.BsonValue = bsonValue;
             }
 
             _astarteDbContext.SaveChanges();

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteDevicePropertyInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteDevicePropertyInterface.cs
@@ -58,8 +58,11 @@ namespace AstarteDeviceSDKCSharp.Protocol
                 Trace.WriteLine(e.Message);
             }
 
-            if (storedValue == null)
+            if (!(storedValue?.PayloadEquality(payload) ?? false))
             {
+
+                transport.SendIndividualValue(this, path, payload);
+
                 try
                 {
                     propertyStorage.SetStoredValue(this.GetInterfaceName(), path, payload,
@@ -70,14 +73,6 @@ namespace AstarteDeviceSDKCSharp.Protocol
                     throw new AstarteTransportException("Property storage failure", e);
                 }
             }
-            else
-            {
-                if (!storedValue.PayloadEquality(payload))
-                {
-                    transport.SendIndividualValue(this, path, payload);
-                }
-            }
-
         }
 
         public void UnsetProperty(string path)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - Unreleased
+### Fixed
+- Fix a bug preventing sending of non-existing properties in local storage.
+
 ## [0.5.3] - 2023-06-07
 ### Fixed
 - Fix payload validation on the aggregated object interface.


### PR DESCRIPTION
Fix a bug preventing sending of non-existing properties in local storage. If the set property isn't in local storage then first send it to Astarte.