### PR TITLE
Update MQTTNet library version from 3.0.16 to 3.1.2

### DIFF
--- a/AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj
+++ b/AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0 -->
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="JWT" Version="9.0.3" />
-    <PackageReference Include="MQTTnet" Version="3.0.16" />
+    <PackageReference Include="MQTTnet" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />


### PR DESCRIPTION
Update MQTTNet library version from 3.0.16 to 3.1.2. Version 3.1.2 resolved memory leaks and decreases object allocations.