### PR TITLE
Parse body from failed requests on pairing API

### DIFF
--- a/AstarteDeviceSDKCSharp/AstartePairingService.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingService.cs
@@ -61,11 +61,15 @@ namespace AstarteDeviceSDKCSharp
 
             if (!response.IsSuccessStatusCode)
             {
+                string responseContent = await response.Content.ReadAsStringAsync();
+
+                responseContent = responseContent.IsNullOrEmpty() ? "empty" : responseContent;
+
                 throw new AstartePairingException(
                             "Request to Pairing API failed with "
                                 + response.StatusCode.ToString()
                                 + ". Returned body is "
-                                + response.Content.ToString());
+                                + responseContent);
             }
 
             var transportInfo = await response.Content.ReadAsStringAsync();
@@ -158,11 +162,15 @@ namespace AstarteDeviceSDKCSharp
 
                 if (!response.IsSuccessStatusCode)
                 {
+                    string responseContent = await response.Content.ReadAsStringAsync();
+
+                    responseContent = responseContent.IsNullOrEmpty() ? "empty" : responseContent;
+
                     throw new AstartePairingException(
                               "Request to Pairing API failed with "
                                   + response.StatusCode.ToString()
                                   + ". Returned body is "
-                                  + response.Content.ToString());
+                                  + responseContent);
                 }
 
                 var certificate = JsonConvert
@@ -346,13 +354,17 @@ namespace AstarteDeviceSDKCSharp
             content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             HttpResponseMessage response = await client.PostAsync(_pairingUrl + $"/{_astarteRealm}/agent/devices", content);
 
-            if (!response.IsSuccessStatusCode || response.Content == null)
+            if (!response.IsSuccessStatusCode)
             {
+                string responseContent = await response.Content.ReadAsStringAsync();
+
+                responseContent = responseContent.IsNullOrEmpty() ? "empty" : responseContent;
+
                 throw new AstartePairingException(
                     "Request to device register API failed with "
                         + response.StatusCode
                         + ". Returned body is "
-                        + (response.Content != null ? await response.Content.ReadAsStringAsync() : "empty"));
+                        + responseContent);
             }
 
             dynamic? credential = JsonConvert.DeserializeObject<object>(await response.Content.ReadAsStringAsync());

--- a/AstarteDeviceSDKCSharp/AstartePairingService.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingService.cs
@@ -52,12 +52,11 @@ namespace AstarteDeviceSDKCSharp
         {
             List<AstarteTransport> transports = new();
             // Prepare the Pairing API request
-            HttpClient client = new();
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer",
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer",
             credentialSecret);
 
-            var response = await client
-                        .GetAsync(_pairingUrl + $"/{_astarteRealm}/devices/{deviceId}");
+            var response = await _httpClient.GetAsync(
+                _pairingUrl + $"/{_astarteRealm}/devices/{deviceId}");
 
             if (!response.IsSuccessStatusCode)
             {
@@ -133,8 +132,7 @@ namespace AstarteDeviceSDKCSharp
             }
 
             // Prepare the Pairing API request
-            HttpClient client = new();
-            client.DefaultRequestHeaders.Authorization =
+            _httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", credentialSecret);
 
             try
@@ -156,7 +154,7 @@ namespace AstarteDeviceSDKCSharp
                 HttpContent content = new StringContent(json);
                 content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
-                var response = await client.PostAsync(_pairingUrl +
+                var response = await _httpClient.PostAsync(_pairingUrl +
                 $"/{_astarteRealm}/devices/{deviceId}/protocols/astarte_mqtt_v1/credentials",
                 content);
 


### PR DESCRIPTION

- Response body from failed HTTP requests returns the wrong message:

![Capture](https://github.com/astarte-platform/astarte-device-sdk-csharp/assets/64848448/73679bc6-fdde-4133-be25-8c6e7a42cf3d),
it should be parsed from json response like in the example below:
![Capture2](https://github.com/astarte-platform/astarte-device-sdk-csharp/assets/64848448/0ab97b54-85b3-4d47-947b-b274a86ec6d7)

- Reused Http client settings for better performance.
