### PR TITLE
Implement fallout strategy failed individual message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - Unreleased
+### Added
+- Add a fallout strategy for individual failed messages.
+
 ## [0.6.0] - 2023-12-18
 ### Added
 - Add the capability to update the introspection dynamically.


### PR DESCRIPTION
Astarte Device SDK does not currently implement a fallout strategy for individual datastream messages.

In the 'Class AstarteMqttV1Transport,' the method 'SendIndividualValue' handles the 'MqttCommunicationException' by calling the method 'HandleDatastreamFailedPublish' for the stored message.

When the device loses connection with Astarte, failed individual datastream messages will be stored. The method of storage can be determined from a mapping of the interface field 'Retention.' Retention types include 'volatile,' which is stored in cache memory, and 'stored,' which is saved in the local database. The default retention value is 'discarded,' and the 'discard' message retention type does not save.

Testing:

1. Set up the device to send individual datastream messages with the interface mapping set to 'volatile' or 'stored.'
2. Turn off the network on the device.
3. Wait until the device loses connection to Astarte.
4. Turn on the network on the device.

Finally, failed messages will be sent to Astarte.