### PR TITLE
Update the RetryFailedMessages() method

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageStorage.cs
@@ -106,5 +106,41 @@ namespace AstarteDeviceSDKCSharp.Data
 
             _astarteDbContext.SaveChanges();
         }
+
+        public bool IsCacheEmpty()
+        {
+            return !_astarteFailedMessageVolatile.Any();
+        }
+
+        public AstarteFailedMessageEntry? PeekFirstCache()
+        {
+            return _astarteFailedMessageVolatile
+            .OrderBy(x => x.Id)
+            .FirstOrDefault();
+        }
+
+        public void RejectFirstCache()
+        {
+            var failedMessages = _astarteFailedMessageVolatile
+            .OrderBy(x => x.Id)
+            .ToList();
+
+            if (failedMessages.Count() > 0)
+            {
+                _astarteDbContext.AstarteFailedMessages.Remove(failedMessages.First());
+            }
+        }
+
+        public void AckFirstCache()
+        {
+            var failedMessages = _astarteFailedMessageVolatile
+            .OrderBy(x => x.Id)
+            .ToList();
+
+            if (failedMessages.Count() > 0)
+            {
+                _astarteFailedMessageVolatile.Remove(failedMessages.First());
+            }
+        }
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -32,10 +32,18 @@ namespace AstarteDeviceSDKCSharp.Data
 
         bool IsEmpty();
 
+        bool IsCacheEmpty();
+
         AstarteFailedMessageEntry? PeekFirst();
+
+        AstarteFailedMessageEntry? PeekFirstCache();
 
         void AckFirst();
 
+        void AckFirstCache();
+
         void RejectFirst();
+
+        void RejectFirstCache();
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0] - Unreleased
 ### Added
 - Add a fallout strategy for individual failed messages.
+- Resend failed messages stored in the cache memory.
 
 ## [0.6.0] - 2023-12-18
 ### Added


### PR DESCRIPTION
The Astarte Device SDK currently lacks support for sending outfall messages stored in the cache memory.

Within the 'AstarteMqttV1Transport' class, the 'RetryFailedMessages' method exclusively handles messages stored in the local database. It requires updates to manage resending messages stored in the device's cache memory.

Upon successful reconnection to Astarte, resend the data stored in the cache memory to Astarte. Once a message is sent, remove it from the device's memory.

The duration for which a message remains stored in the cache memory is determined by the 'expiry' property in the mapping.

Testing:

1. Set up the device to send individual datastream messages with the interface mapping set to 'volatile'.
2. Turn off the network on the device.
3. Wait until the device loses connection to Astarte.
4. Turn on the network on the device.

Finally, failed messages will be sent to Astarte.