### PR TITLE
[Fix]: Use DirectorySeparatorChar to build persistence directory path

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstarteDbContext.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteDbContext.cs
@@ -42,7 +42,7 @@ namespace AstarteDeviceSDKCSharp.Data
 
             if (!optionsBuilder.IsConfigured)
             {
-                optionsBuilder.UseSqlite("Filename = " + _persistencyDir + "\\AstarteDeviceDb", option =>
+                optionsBuilder.UseSqlite($"Filename = {_persistencyDir}{Path.DirectorySeparatorChar}AstarteDeviceDb", option =>
             {
                 option.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName);
             });


### PR DESCRIPTION
Linux file system does not recognize // in the path for the persistence directory.

Changed the persistence directory path to be recognized in the Linux file system. The location for creating the database has been relocated inside the crypto directory.

