### PR TITLE
Refactor message expiry time check logic

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstarteDbContext.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteDbContext.cs
@@ -27,6 +27,10 @@ namespace AstarteDeviceSDKCSharp.Data
     {
         private readonly string _persistencyDir = string.Empty;
 
+        public AstarteDbContext()
+        {
+
+        }
         public AstarteDbContext(string persistencyDir)
         {
             _persistencyDir = persistencyDir;

--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
@@ -37,7 +37,7 @@ namespace AstarteDeviceSDKCSharp.Data
 
         [Column("absolute_expiry")]
         [Required]
-        protected long absoluteExpiry;
+        public long AbsoluteExpiry { get; set; }
 
 
         public AstarteFailedMessageEntry(int qos, byte[] payload, string topic)
@@ -45,7 +45,7 @@ namespace AstarteDeviceSDKCSharp.Data
             Qos = qos;
             Payload = payload;
             Topic = topic;
-            absoluteExpiry = 0;
+            AbsoluteExpiry = 0;
         }
 
         public AstarteFailedMessageEntry(int qos, byte[] payload, string topic,
@@ -54,7 +54,7 @@ namespace AstarteDeviceSDKCSharp.Data
             Qos = qos;
             Payload = payload;
             Topic = topic;
-            absoluteExpiry = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) + relativeExpiry;
+            AbsoluteExpiry = (DateTimeOffset.UtcNow.ToUnixTimeSeconds()) + relativeExpiry;
         }
 
         public string GetTopic()
@@ -72,9 +72,14 @@ namespace AstarteDeviceSDKCSharp.Data
             return Qos;
         }
 
+        public long GetExpiry()
+        {
+            return AbsoluteExpiry;
+        }
+
         public bool IsExpired()
         {
-            return absoluteExpiry > (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            return AbsoluteExpiry > (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         }
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
@@ -77,9 +77,5 @@ namespace AstarteDeviceSDKCSharp.Data
             return AbsoluteExpiry;
         }
 
-        public bool IsExpired()
-        {
-            return AbsoluteExpiry > (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
-        }
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageStorage.cs
@@ -172,5 +172,10 @@ namespace AstarteDeviceSDKCSharp.Data
                 _astarteFailedMessageVolatile.Remove(failedMessages.First());
             }
         }
+
+        public bool IsExpired(long expire)
+        {
+            return expire != 0 ? (DateTimeOffset.UtcNow.ToUnixTimeSeconds() > expire) : false;
+        }
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessage.cs
@@ -28,6 +28,6 @@ namespace AstarteDeviceSDKCSharp.Data
 
         int GetQos();
 
-        bool IsExpired();
+        long GetExpiry();
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -45,5 +45,7 @@ namespace AstarteDeviceSDKCSharp.Data
         void RejectFirst();
 
         void RejectFirstCache();
+
+        bool IsExpired(long expire);
     }
 }

--- a/AstarteDeviceSDKCSharp/Migrations/20240221083848_AddColumnExpiry.Designer.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240221083848_AddColumnExpiry.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstarteDeviceSDKCSharp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AstarteDeviceSDKCSharp.Migrations
 {
     [DbContext(typeof(AstarteDbContext))]
-    partial class AstarteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240221083848_AddColumnExpiry")]
+    partial class AddColumnExpiry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.13");

--- a/AstarteDeviceSDKCSharp/Migrations/20240221083848_AddColumnExpiry.Designer.cs.license
+++ b/AstarteDeviceSDKCSharp/Migrations/20240221083848_AddColumnExpiry.Designer.cs.license
@@ -1,0 +1,5 @@
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/AstarteDeviceSDKCSharp/Migrations/20240221083848_AddColumnExpiry.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240221083848_AddColumnExpiry.cs
@@ -1,0 +1,31 @@
+﻿// This file is part of Astarte.
+//
+// Copyright 2024 SECO Mind Srl
+//
+// SPDX-License-Identifier: Apache-2.0
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AstarteDeviceSDKCSharp.Migrations
+{
+    public partial class AddColumnExpiry : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "absolute_expiry",
+                table: "AstarteFailedMessages",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "absolute_expiry",
+                table: "AstarteFailedMessages");
+        }
+    }
+}

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
@@ -197,7 +197,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                     return;
                 }
 
-                if (failedMessage.IsExpired())
+                if (_failedMessageStorage.IsExpired(failedMessage.GetExpiry()))
                 {
                     // No need to send this anymore, drop it
                     _failedMessageStorage.RejectFirst();
@@ -218,7 +218,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                 _failedMessageStorage.AckFirst();
             }
 
-            while (!_failedMessageStorage.IsCacheEmpty())
+            while (_failedMessageStorage.IsCacheEmpty())
             {
                 IAstarteFailedMessage? failedMessage = _failedMessageStorage.PeekFirstCache();
                 if (failedMessage is null)
@@ -226,7 +226,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                     return;
                 }
 
-                if (failedMessage.IsExpired())
+                if (_failedMessageStorage.IsExpired(failedMessage.GetExpiry()))
                 {
                     // No need to send this anymore, drop it
                     _failedMessageStorage.RejectFirstCache();

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/MutualSSLAuthenticationMqttConnectionInfo.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/MutualSSLAuthenticationMqttConnectionInfo.cs
@@ -40,6 +40,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
             .WithCleanSession(false)
             .WithCommunicationTimeout(TimeSpan.FromSeconds(60))
             .WithKeepAlivePeriod(TimeSpan.FromSeconds(60))
+            .WithSessionExpiryInterval(0)
             .Build();
 
             _clientId = $"{astarteRealm}/{deviceId}";


### PR DESCRIPTION
# Make changes to resolve reported issues:
- missing messages (time of expiry messages calculated wrong )
- duplicate messages  (broker caches messages)

# This pull request introduces several enhancements and refinements to the project:


 - Added a new column, AbsoluteExpiry, in the AstarteFailedMessageEntry table to facilitate the management of message expiry.
- Generated a migration with the command dotnet ef migrations add AddColumnExpiry and applied the migration using dotnet ef database update.
- Implemented an empty constructor in the AstarteDbContext class to enable the generation of new migrations.
- Refactored and relocated the IsExpired method from the AstarteFailedMessageEntry class to the AstarteFailedMessageStorage class. This refactor includes updating the logic for calculating message expiry based on the moment when fallback messages are stored in the database.
- Updated the MutualSSLAuthenticationMqttConnectionInfo constructor by adding the WithSessionExpiryInterval property and setting it to 0 to prevent caching messages in the broker.

# Testing:

- Set up the device to send individual datastream messages with the interface mapping set to 'volatile'.
- Turn down  vernemq container on Astarte machine.
- Wait until the device loses connection to Astarte.
- Turn  vernemq container on Astarte machine.

#Test results
Start sending data:
![image](https://github.com/astarte-platform/astarte-device-sdk-csharp/assets/33448743/65fa3e78-489b-435c-bc6c-d70792ee0373)
Sve fallback messages in the database:
![image](https://github.com/astarte-platform/astarte-device-sdk-csharp/assets/33448743/d14dae6c-9048-491f-9a24-df41ec835752)
Resend to Astarte:
![image](https://github.com/astarte-platform/astarte-device-sdk-csharp/assets/33448743/ba44ae6a-f7bd-4999-9a4f-67279e625122)









