### PR TITLE
Refactor failed message storage

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -38,11 +38,11 @@ namespace AstarteDeviceSDKCSharp.Data
 
         AstarteFailedMessageEntry? PeekFirstCache();
 
-        void AckFirst();
+        void Ack(AstarteFailedMessageEntry failedMessages);
 
         void AckFirstCache();
 
-        void RejectFirst();
+        void Reject(AstarteFailedMessageEntry astarteFailedMessages);
 
         void RejectFirstCache();
 

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
@@ -191,7 +191,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
 
             while (!_failedMessageStorage.IsEmpty())
             {
-                IAstarteFailedMessage? failedMessage = _failedMessageStorage.PeekFirst();
+                AstarteFailedMessageEntry? failedMessage = _failedMessageStorage.PeekFirst();
                 if (failedMessage is null)
                 {
                     return;
@@ -200,7 +200,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                 if (_failedMessageStorage.IsExpired(failedMessage.GetExpiry()))
                 {
                     // No need to send this anymore, drop it
-                    _failedMessageStorage.RejectFirst();
+                    _failedMessageStorage.Reject(failedMessage);
                     continue;
                 }
 
@@ -215,10 +215,10 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                 {
                     throw new AstarteTransportException(e.Message);
                 }
-                _failedMessageStorage.AckFirst();
+                _failedMessageStorage.Ack(failedMessage);
             }
 
-            while (_failedMessageStorage.IsCacheEmpty())
+            while (!_failedMessageStorage.IsCacheEmpty())
             {
                 IAstarteFailedMessage? failedMessage = _failedMessageStorage.PeekFirstCache();
                 if (failedMessage is null)


### PR DESCRIPTION
# Reported issues
Report issue with sending fallback messages :
 - duplicate messages 
 - infinite loop sending on messages
 - does not send all fallback messages
 
EF core does not support multithreading applications. Application entered in deadlock because at the same time insert and delete from the database.

## Changes
Refactor handling messages from the database to avoid deadlock on the database.

- Implement transaction in `InsertStored` method.
- Refactor the methods `Ack` and `Reject` to accept messages from the `RetryFailedMessages` method instead of directly from the database.


## Testing
Set up the device to send individual datastream messages with the interface mapping set to 'stored'.
Turn down vernemq container on Astarte machine.
Wait until the device loses connection to Astarte.
Turn vernemq container on Astarte machine.