### PR TITLE
Update version MQTTnet library

### DIFF
--- a/AstarteDeviceSDKCSharp.Tests/AstartePairingServiceTest.cs
+++ b/AstarteDeviceSDKCSharp.Tests/AstartePairingServiceTest.cs
@@ -49,7 +49,7 @@ namespace AstarteDeviceSDKCSharp.Tests
                   .WithHeader("Content-Type", "application/json; charset=utf-8")
               );
 
-            _service = new AstartePairingService($"{_server.Urls[0]}", "test");
+            _service = new AstartePairingService($"{_server.Urls[0]}", "test", TimeSpan.FromMilliseconds(500));
             //Assert
             _ = await Assert.ThrowsAsync<AstartePairingException>(() =>
             //Act
@@ -75,7 +75,7 @@ namespace AstarteDeviceSDKCSharp.Tests
                     + "}")
               ); ;
 
-            _service = new AstartePairingService($"{_server.Urls[0]}", "test");
+            _service = new AstartePairingService($"{_server.Urls[0]}", "test", TimeSpan.FromMilliseconds(500));
 
             //Assert
             _ = await Assert.ThrowsAsync<AstartePairingException>(() =>
@@ -116,7 +116,7 @@ namespace AstarteDeviceSDKCSharp.Tests
                   .WithHeader("Content-Type", "application/json; charset=utf-8")
                   .WithBody(responseBody)
               );
-            _service = new AstartePairingService($"{_server.Urls[0]}", "test");
+            _service = new AstartePairingService($"{_server.Urls[0]}", "test", TimeSpan.FromMilliseconds(500));
 
             //Act
             string credentialSecret = await _service.RegisterDeviceWithJwtToken(deviceId, expectedCredentialSecret);
@@ -151,7 +151,7 @@ namespace AstarteDeviceSDKCSharp.Tests
                   .WithHeader("Content-Type", "application/json; charset=utf-8")
               );
 
-            _service = new AstartePairingService($"{_server.Urls[0]}", "test");
+            _service = new AstartePairingService($"{_server.Urls[0]}", "test", TimeSpan.FromMilliseconds(500));
             //Assert
             _ = await Assert.ThrowsAsync<AstartePairingException>(() =>
             //Act
@@ -198,7 +198,7 @@ namespace AstarteDeviceSDKCSharp.Tests
                 "JdorKpZMgsh6rzLQ==");
             string privateKey = new(PemEncoding.Write("EC PRIVATE KEY", array).ToArray());
 
-            _service = new AstartePairingService($"{_server.Urls[0]}", "test");
+            _service = new AstartePairingService($"{_server.Urls[0]}", "test", TimeSpan.FromMilliseconds(500));
             var myPath = Path.GetDirectoryName(
                 System.Reflection.Assembly.GetExecutingAssembly().Location);
             myPath = Path.Combine(myPath, "key.pem");
@@ -242,7 +242,7 @@ namespace AstarteDeviceSDKCSharp.Tests
             Uri _expectedPairingUrl = new Uri("http://localhost:4003");
 
             //Act
-            _service = new AstartePairingService(_expectedPairingUrl.OriginalString, "test");
+            _service = new AstartePairingService(_expectedPairingUrl.OriginalString, "test", TimeSpan.FromMilliseconds(500));
 
             Uri _actualPairingUrl = _service.PairingUrl();
 
@@ -260,7 +260,7 @@ namespace AstarteDeviceSDKCSharp.Tests
             Uri _expectedPairingUrl = new Uri("https://astarte.instance.test/pairing");
 
             //Act
-            _service = new AstartePairingService(_expectedPairingUrl.OriginalString, "test");
+            _service = new AstartePairingService(_expectedPairingUrl.OriginalString, "test", TimeSpan.FromMilliseconds(500));
 
             Uri _actualPairingUrl = _service.PairingUrl();
 

--- a/AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj
+++ b/AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0 -->
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="JWT" Version="9.0.3" />
-    <PackageReference Include="MQTTnet" Version="3.1.2" />
+    <PackageReference Include="MQTTnet" Version="4.1.4.563" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />

--- a/AstarteDeviceSDKCSharp/AstartePairingHandler.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingHandler.cs
@@ -33,15 +33,17 @@ namespace AstarteDeviceSDKCSharp
         readonly AstarteCryptoStore _cryptoStore;
         private List<AstarteTransport>? _transports;
         private X509Certificate2? _certificate;
+        private TimeSpan _timeOut;
 
         public AstartePairingHandler(string pairingUrl, string astarteRealm, string deviceId,
-        string credentialSecret, AstarteCryptoStore astarteCryptoStore)
+        string credentialSecret, AstarteCryptoStore astarteCryptoStore, TimeSpan timeout)
         {
             _astarteRealm = astarteRealm;
             _deviceId = deviceId;
             _credentialSecret = credentialSecret;
             _cryptoStore = astarteCryptoStore;
-            _AstartePairingService = new AstartePairingService(pairingUrl, astarteRealm);
+            _timeOut = timeout;
+            _AstartePairingService = new AstartePairingService(pairingUrl, astarteRealm, timeout);
 
             _certificate = _cryptoStore.GetCertificate();
             if (_certificate == null)
@@ -60,7 +62,7 @@ namespace AstarteDeviceSDKCSharp
         private async Task ReloadTransports()
         {
             _transports = await _AstartePairingService.ReloadTransports(_credentialSecret,
-            _cryptoStore, _deviceId);
+            _cryptoStore, _deviceId, _timeOut);
         }
 
         public List<AstarteTransport> GetTransports()

--- a/AstarteDeviceSDKCSharp/AstartePairingService.cs
+++ b/AstarteDeviceSDKCSharp/AstartePairingService.cs
@@ -39,16 +39,18 @@ namespace AstarteDeviceSDKCSharp
         private readonly string _astarteRealm;
         private readonly HttpClient _httpClient;
 
-        public AstartePairingService(string pairingUrl, string astarteRealm)
+        public AstartePairingService(string pairingUrl, string astarteRealm, TimeSpan timeOut)
         {
             _astarteRealm = astarteRealm;
             _pairingUrl = new Uri($"{pairingUrl.TrimEnd('/')}/v1");
-            _httpClient = new HttpClient();
-
+            _httpClient = new HttpClient
+            {
+                Timeout = timeOut
+            };
         }
 
         internal async Task<List<AstarteTransport>> ReloadTransports(string credentialSecret,
-        AstarteCryptoStore astarteCryptoStore, string deviceId)
+        AstarteCryptoStore astarteCryptoStore, string deviceId, TimeSpan timeOut)
         {
             List<AstarteTransport> transports = new();
             // Prepare the Pairing API request
@@ -101,7 +103,8 @@ namespace AstarteDeviceSDKCSharp
                            _astarteRealm,
                            deviceId,
                            item,
-                           astarteCryptoStore);
+                           astarteCryptoStore,
+                           timeOut);
 
                         transports.Add(supportedTransport);
                     }
@@ -134,6 +137,7 @@ namespace AstarteDeviceSDKCSharp
             // Prepare the Pairing API request
             _httpClient.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Bearer", credentialSecret);
+
 
             try
             {

--- a/AstarteDeviceSDKCSharp/Crypto/AstarteCryptoStore.cs
+++ b/AstarteDeviceSDKCSharp/Crypto/AstarteCryptoStore.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-using MQTTnet.Client.Options;
+using MQTTnet.Client;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -55,13 +55,13 @@ namespace AstarteDeviceSDKCSharp.Crypto
 
         }
 
-        public void SaveCertificateIfNotExist(X509Certificate2 x509Certificate)
+        public void SaveCertificateIfNotExist(X509Certificate2 x509Certificate2)
         {
             //Save certificate to file
             try
             {
                 File.WriteAllText(Path.Combine(_cryptoStoreDir, "device.crt"),
-                new(PemEncoding.Write("CERTIFICATE", x509Certificate.GetRawCertData()).ToArray()));
+                new(PemEncoding.Write("CERTIFICATE", x509Certificate2.GetRawCertData()).ToArray()));
             }
             catch (DirectoryNotFoundException ex)
             {

--- a/AstarteDeviceSDKCSharp/Crypto/AstarteMutualTLSParametersFactory.cs
+++ b/AstarteDeviceSDKCSharp/Crypto/AstarteMutualTLSParametersFactory.cs
@@ -18,12 +18,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-using MQTTnet.Client.Options;
+using MQTTnet.Client;
 using System.Security.Cryptography.X509Certificates;
 
 namespace AstarteDeviceSDKCSharp.Crypto
 {
-    public class AstarteMutualTLSParametersFactory : MqttClientOptionsBuilderTlsParameters
+    public class AstarteMutualTLSParametersFactory
     {
 
         private readonly MqttClientOptionsBuilderTlsParameters _tlsOptions;
@@ -33,14 +33,19 @@ namespace AstarteDeviceSDKCSharp.Crypto
             _tlsOptions = new MqttClientOptionsBuilderTlsParameters
             {
                 UseTls = true,
-                Certificates = new List<X509Certificate?>
+                Certificates = new List<X509Certificate2?>
                 {
                     cryptoStore.GetCertificate()
                 },
                 IgnoreCertificateChainErrors = cryptoStore.IgnoreSSLErrors,
                 IgnoreCertificateRevocationErrors = cryptoStore.IgnoreSSLErrors,
                 SslProtocol = System.Security.Authentication.SslProtocols.Tls12,
-                AllowUntrustedCertificates = cryptoStore.IgnoreSSLErrors
+                AllowUntrustedCertificates = cryptoStore.IgnoreSSLErrors,
+                CertificateValidationHandler = eventArgs =>
+                {
+                    eventArgs.Certificate = cryptoStore.GetCertificate();
+                    return true;
+                }
             };
         }
 

--- a/AstarteDeviceSDKCSharp/Crypto/IAstarteCryptoStore.cs
+++ b/AstarteDeviceSDKCSharp/Crypto/IAstarteCryptoStore.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-using MQTTnet.Client.Options;
+using MQTTnet.Client;
 using System.Security.Cryptography.X509Certificates;
 
 namespace AstarteDeviceSDKCSharp.Crypto

--- a/AstarteDeviceSDKCSharp/Transport/AstarteTransportFactory.cs
+++ b/AstarteDeviceSDKCSharp/Transport/AstarteTransportFactory.cs
@@ -29,7 +29,7 @@ namespace AstarteDeviceSDKCSharp.Transport
 
         public static AstarteTransport? CreateAstarteTransportFromPairing
         (AstarteProtocolType protocolType, string astarteRealm,
-        string deviceId, dynamic protocolData, AstarteCryptoStore astarteCryptoStore)
+        string deviceId, dynamic protocolData, AstarteCryptoStore astarteCryptoStore, TimeSpan timeOut)
         {
 
             switch (protocolType)
@@ -40,7 +40,8 @@ namespace AstarteDeviceSDKCSharp.Transport
                         new MutualSSLAuthenticationMqttConnectionInfo(brokerUrl,
                         astarteRealm,
                         deviceId,
-                        astarteCryptoStore.GetMqttClientOptionsBuilderTlsParameters())
+                        astarteCryptoStore.GetMqttClientOptionsBuilderTlsParameters(),
+                        timeOut)
                         );
                 default:
                     return null;

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/IMqttConnectionInfo.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/IMqttConnectionInfo.cs
@@ -30,5 +30,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
         string GetClientId();
 
         MqttClientOptions GetMqttConnectOptions();
+
+        TimeSpan GetTimeOut();
     }
 }

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/IMqttConnectionInfo.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/IMqttConnectionInfo.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-using MQTTnet.Client.Options;
+using MQTTnet.Client;
 
 
 namespace AstarteDeviceSDKCSharp.Transport.MQTT
@@ -29,6 +29,6 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
 
         string GetClientId();
 
-        IMqttClientOptions GetMqttConnectOptions();
+        MqttClientOptions GetMqttConnectOptions();
     }
 }

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/MutualSSLAuthenticationMqttConnectionInfo.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/MutualSSLAuthenticationMqttConnectionInfo.cs
@@ -28,9 +28,10 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
         private readonly Uri _brokerUrl;
         private readonly MqttClientOptions _mqttConnectOptions;
         private readonly string _clientId = string.Empty;
+        private readonly TimeSpan _timeOut;
 
         public MutualSSLAuthenticationMqttConnectionInfo(Uri brokerUrl, string astarteRealm,
-        string deviceId, MqttClientOptionsBuilderTlsParameters tlsOptions)
+        string deviceId, MqttClientOptionsBuilderTlsParameters tlsOptions, TimeSpan timeOut)
         {
             _brokerUrl = brokerUrl;
             _mqttConnectOptions = new MqttClientOptionsBuilder()
@@ -40,14 +41,18 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
             .WithCleanSession(false)
             .WithKeepAlivePeriod(TimeSpan.FromSeconds(60))
             .WithSessionExpiryInterval(0)
+            .WithTimeout(timeOut)
             .Build();
 
+            _timeOut = timeOut;
             _clientId = $"{astarteRealm}/{deviceId}";
         }
 
         public Uri GetBrokerUrl() => _brokerUrl;
 
         public string GetClientId() => _clientId;
+
+        public TimeSpan GetTimeOut() => _timeOut;
 
         public MqttClientOptions GetMqttConnectOptions() => _mqttConnectOptions;
     }

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/MutualSSLAuthenticationMqttConnectionInfo.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/MutualSSLAuthenticationMqttConnectionInfo.cs
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-using MQTTnet.Client.Options;
+using MQTTnet.Client;
 
 namespace AstarteDeviceSDKCSharp.Transport.MQTT
 {
@@ -26,7 +26,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
     {
 
         private readonly Uri _brokerUrl;
-        private readonly IMqttClientOptions _mqttConnectOptions;
+        private readonly MqttClientOptions _mqttConnectOptions;
         private readonly string _clientId = string.Empty;
 
         public MutualSSLAuthenticationMqttConnectionInfo(Uri brokerUrl, string astarteRealm,
@@ -38,7 +38,6 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
             .WithTcpServer(_brokerUrl.Host, _brokerUrl.Port)
             .WithTls(tlsOptions)
             .WithCleanSession(false)
-            .WithCommunicationTimeout(TimeSpan.FromSeconds(60))
             .WithKeepAlivePeriod(TimeSpan.FromSeconds(60))
             .WithSessionExpiryInterval(0)
             .Build();
@@ -50,6 +49,6 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
 
         public string GetClientId() => _clientId;
 
-        public IMqttClientOptions GetMqttConnectOptions() => _mqttConnectOptions;
+        public MqttClientOptions GetMqttConnectOptions() => _mqttConnectOptions;
     }
 }

--- a/AstarteDeviceSDKCSharpE2E.Tests/Utilities/AstarteDeviceSingleton.cs
+++ b/AstarteDeviceSDKCSharpE2E.Tests/Utilities/AstarteDeviceSingleton.cs
@@ -62,6 +62,7 @@ namespace AstarteDeviceSDKCSharpE2E.Tests.Utilities
                         new MockInterfaceProvider(),
                         astarteMockData.PairingUrl,
                         cryptoStoreDir,
+                        TimeSpan.FromMilliseconds(500),
                         true
                     );
                     astarteDevice.SetAlwaysReconnect(true);

--- a/AstarteDeviceSDKExample/Program.cs
+++ b/AstarteDeviceSDKExample/Program.cs
@@ -71,7 +71,10 @@ namespace AstarteDeviceSDKExample
                 Guid nameSpace = Guid.NewGuid();
                 string macAdress = "0099112233";
                 deviceId = AstarteDeviceIdUtils.GenerateId(nameSpace, macAdress);
-                credentialsSecret = await new AstartePairingService(pairingUrl, realm)
+                credentialsSecret = await new AstartePairingService(
+                    pairingUrl,
+                    realm,
+                    TimeSpan.FromSeconds(1))
                     .RegisterDeviceWithJwtToken(deviceId, jwt);
             }
 
@@ -93,7 +96,9 @@ namespace AstarteDeviceSDKExample
                 credentialsSecret,
                 interfaceProvider,
                 pairingUrl,
-                cryptoStoreDir);
+                cryptoStoreDir,
+                TimeSpan.FromMilliseconds(500),
+                true);
 
             myDevice.SetAlwaysReconnect(true);
             myDevice.SetAstarteMessageListener(new ExampleMessageListener());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - Unreleased
 ### Added
+- Add timeout to the `AstartePairingService` constructor.
+- Add device connection timeout to the `ÀstarteDevice` constructor.
+- Update version of MQTTNet libary from 3.1.2 to 4.1.4.563.
 - Add a fallout strategy for individual failed messages.
 - Resend failed messages stored in the cache memory.
 


### PR DESCRIPTION
Update version MQTTnet library from 3.1.2 to 4.1.4.563. Refactor strategy for fallback messages.

Updating the MQTTnet library provides benefits such as bug fixes, security patches, performance improvements, new features, compatibility with the latest .NET versions, and better community support.

Implement breaking changes:
 - Rename namespaces 
 - Implement an enum for Qos 
 - Replace handler with events (messages receive and disconnect)

Handling exception to resolve deadlock in threads. With add cancellation timeout token in class `AstarteMqttTransport` method `Connect()`  and handling `AggregateException` in class `AstarteDevice` method `EventualyReconnect()`.
