### PR TITLE
Implement  Managed Client MQTTnet extension

### DIFF
--- a/AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj
+++ b/AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj
@@ -35,6 +35,7 @@ SPDX-License-Identifier: Apache-2.0 -->
     </PackageReference>
     <PackageReference Include="JWT" Version="9.0.3" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
+    <PackageReference Include="MQTTnet.Extensions.ManagedClient" Version="4.1.4.563" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />

--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
@@ -20,9 +20,11 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace AstarteDeviceSDKCSharp.Data
 {
+    [Index(nameof(Guid), Name = "Index_Guid")]
     public class AstarteFailedMessageEntry : IAstarteFailedMessage
     {
         [Key]
@@ -38,19 +40,24 @@ namespace AstarteDeviceSDKCSharp.Data
         [Column("absolute_expiry")]
         [Required]
         public long AbsoluteExpiry { get; set; }
+        [Required]
+        [Column("guid")]
+        public Guid Guid { get; set; }
 
 
-        public AstarteFailedMessageEntry(int qos, byte[] payload, string topic)
+        public AstarteFailedMessageEntry(int qos, byte[] payload, string topic, Guid guid)
         {
+            Guid = guid;
             Qos = qos;
             Payload = payload;
             Topic = topic;
             AbsoluteExpiry = 0;
         }
 
-        public AstarteFailedMessageEntry(int qos, byte[] payload, string topic,
+        public AstarteFailedMessageEntry(int qos, byte[] payload, string topic, Guid guid,
         int relativeExpiry)
         {
+            Guid = guid;
             Qos = qos;
             Payload = payload;
             Topic = topic;
@@ -77,5 +84,9 @@ namespace AstarteDeviceSDKCSharp.Data
             return AbsoluteExpiry;
         }
 
+        public Guid GetGuid()
+        {
+            return Guid;
+        }
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessage.cs
@@ -29,5 +29,7 @@ namespace AstarteDeviceSDKCSharp.Data
         int GetQos();
 
         long GetExpiry();
+
+        Guid GetGuid();
     }
 }

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -18,34 +18,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+using MQTTnet.Extensions.ManagedClient;
+
 namespace AstarteDeviceSDKCSharp.Data
 {
-    public interface IAstarteFailedMessageStorage
+    public interface IAstarteFailedMessageStorage : IManagedMqttClientStorage
     {
-        void InsertVolatile(String topic, byte[] payload, int qos);
+        void InsertVolatile(String topic, byte[] payload, int qos, Guid guid);
 
-        void InsertVolatile(String topic, byte[] payload, int qos, int relativeExpiry);
+        void InsertVolatile(String topic, byte[] payload, int qos, Guid guid, int relativeExpiry);
 
-        void InsertStored(String topic, byte[] payload, int qos);
+        Task InsertStored(String topic, byte[] payload, int qos, Guid guid);
 
-        void InsertStored(String topic, byte[] payload, int qos, int relativeExpiry);
+        Task InsertStored(String topic, byte[] payload, int qos, Guid guid, int relativeExpiry);
 
-        bool IsEmpty();
+        Task Reject(AstarteFailedMessageEntry astarteFailedMessages);
 
-        bool IsCacheEmpty();
-
-        AstarteFailedMessageEntry? PeekFirst();
-
-        AstarteFailedMessageEntry? PeekFirstCache();
-
-        void Ack(AstarteFailedMessageEntry failedMessages);
-
-        void AckFirstCache();
-
-        void Reject(AstarteFailedMessageEntry astarteFailedMessages);
-
-        void RejectFirstCache();
+        void RejectCache(AstarteFailedMessageEntry astarteFailedMessages);
 
         bool IsExpired(long expire);
+
+        Task DeleteByGuidAsync(ManagedMqttApplicationMessage applicationMessage);
     }
 }

--- a/AstarteDeviceSDKCSharp/Migrations/20240418081235_AddMessageGuidColumn.Designer.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240418081235_AddMessageGuidColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstarteDeviceSDKCSharp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AstarteDeviceSDKCSharp.Migrations
 {
     [DbContext(typeof(AstarteDbContext))]
-    partial class AstarteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240418081235_AddMessageGuidColumn")]
+    partial class AddMessageGuidColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.13");

--- a/AstarteDeviceSDKCSharp/Migrations/20240418081235_AddMessageGuidColumn.Designer.cs.license
+++ b/AstarteDeviceSDKCSharp/Migrations/20240418081235_AddMessageGuidColumn.Designer.cs.license
@@ -1,0 +1,5 @@
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/AstarteDeviceSDKCSharp/Migrations/20240418081235_AddMessageGuidColumn.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240418081235_AddMessageGuidColumn.cs
@@ -1,0 +1,40 @@
+﻿// This file is part of Astarte.
+//
+// Copyright 2024 SECO Mind Srl
+//
+// SPDX-License-Identifier: Apache-2.0
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AstarteDeviceSDKCSharp.Migrations
+{
+    public partial class AddMessageGuidColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "guid",
+                table: "AstarteFailedMessages",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateIndex(
+                name: "Index_Guid",
+                table: "AstarteFailedMessages",
+                column: "guid");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "Index_Guid",
+                table: "AstarteFailedMessages");
+
+            migrationBuilder.DropColumn(
+                name: "guid",
+                table: "AstarteFailedMessages");
+        }
+    }
+}

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteDeviceAggregateDatastreamInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteDeviceAggregateDatastreamInterface.cs
@@ -27,12 +27,12 @@ namespace AstarteDeviceSDKCSharp.Protocol
 {
     public class AstarteDeviceAggregateDatastreamInterface : AstarteAggregateDatastreamInterface, IAstarteAggregateDataStreamer
     {
-        public void StreamData(string path, Dictionary<string, object> payload)
+        public async Task StreamData(string path, Dictionary<string, object> payload)
         {
-            StreamData(path, payload, null);
+            await StreamData(path, payload, null);
         }
 
-        public void StreamData(string path, Dictionary<string, object> payload, DateTime? timestamp)
+        public async Task StreamData(string path, Dictionary<string, object> payload, DateTime? timestamp)
         {
             ValidatePayload(path, payload, timestamp);
 
@@ -42,7 +42,7 @@ namespace AstarteDeviceSDKCSharp.Protocol
                 throw new AstarteTransportException("No available transport");
             }
 
-            transport.SendAggregate(this, path, payload, timestamp);
+            await transport.SendAggregate(this, path, payload, timestamp);
         }
 
         public void ValidatePayload(string path, Dictionary<string, object> payload, DateTime? timestamp)

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteDeviceDatastreamInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteDeviceDatastreamInterface.cs
@@ -24,12 +24,12 @@ namespace AstarteDeviceSDKCSharp.Protocol
 {
     public class AstarteDeviceDatastreamInterface : AstarteDatastreamInterface, IAstarteDataStreamer
     {
-        public void StreamData(string path, object payload)
+        public async Task StreamData(string path, object payload)
         {
-            StreamData(path, payload, null);
+            await StreamData(path, payload, null);
         }
 
-        public void StreamData(string path, object payload, DateTime? timestamp)
+        public async Task StreamData(string path, object payload, DateTime? timestamp)
         {
             ValidatePayload(path, payload, timestamp);
             AstarteTransport? transport = GetAstarteTransport();
@@ -38,7 +38,7 @@ namespace AstarteDeviceSDKCSharp.Protocol
                 throw new AstarteTransportException("No available transport");
             }
 
-            transport.SendIndividualValue(this, path, payload, timestamp);
+            await transport.SendIndividualValue(this, path, payload, timestamp);
         }
     }
 }

--- a/AstarteDeviceSDKCSharp/Protocol/IAstarteAggregateDataStreamer.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/IAstarteAggregateDataStreamer.cs
@@ -22,8 +22,8 @@ namespace AstarteDeviceSDKCSharp.Protocol
 {
     public interface IAstarteAggregateDataStreamer
     {
-        void StreamData(String path, Dictionary<String, Object> payload);
+        Task StreamData(String path, Dictionary<String, Object> payload);
 
-        void StreamData(String path, Dictionary<String, Object> payload, DateTime? timestamp);
+        Task StreamData(String path, Dictionary<String, Object> payload, DateTime? timestamp);
     }
 }

--- a/AstarteDeviceSDKCSharp/Protocol/IAstarteDataStreamer.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/IAstarteDataStreamer.cs
@@ -27,7 +27,7 @@ namespace AstarteDeviceSDKCSharp.Protocol
         /// </summary>
         /// <param name="path">Endpoint</param>
         /// <param name="payload">Message for MQTT broker</param>
-        void StreamData(String path, Object payload);
+        Task StreamData(String path, Object payload);
 
         /// <summary>
         /// Method for sending individual values to Astarte with timestamp
@@ -35,6 +35,6 @@ namespace AstarteDeviceSDKCSharp.Protocol
         /// <param name="path">Endpoint</param>
         /// <param name="payload">Message for MQTT broker</param>
         /// <param name="timestamp">UTC</param>
-        void StreamData(String path, Object payload, DateTime? timestamp);
+        Task StreamData(String path, Object payload, DateTime? timestamp);
     }
 }

--- a/AstarteDeviceSDKCSharp/Transport/AstarteTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/AstarteTransport.cs
@@ -88,9 +88,8 @@ namespace AstarteDeviceSDKCSharp.Transport
         }
 
         public abstract Task Connect();
-        public abstract void Disconnect();
+        public abstract Task Disconnect();
         public abstract bool IsConnected();
-        public abstract void RetryFailedMessages();
 
         public void SetPropertyStorage(IAstartePropertyStorage propertyStorage)
         {

--- a/AstarteDeviceSDKCSharpE2E.Tests/AstarteAggregateDeviceTest.cs
+++ b/AstarteDeviceSDKCSharpE2E.Tests/AstarteAggregateDeviceTest.cs
@@ -73,7 +73,7 @@ namespace AstarteDeviceSDKCSharpE2E.Tests
             (AstarteDeviceAggregateDatastreamInterface)astarteDevice
             .GetInterface(interfaceName);
 
-            astarteDeviceAggregateDatastream
+            await astarteDeviceAggregateDatastream
             .StreamData("/%{sensor_id}", astarteMockDevice.MockDataDictionary, DateTime.Now);
             Thread.Sleep(500);
 

--- a/AstarteDeviceSDKCSharpE2E.Tests/AstarteDatastreamDeviceTests.cs
+++ b/AstarteDeviceSDKCSharpE2E.Tests/AstarteDatastreamDeviceTests.cs
@@ -78,7 +78,8 @@ namespace AstarteDeviceSDKCSharpE2E.Tests
 
             foreach (var item in astarteMockDevice.MockDataDictionary)
             {
-                astarteDatastreamInterface.StreamData($"/{item.Key}", item.Value, DateTime.Now);
+                await astarteDatastreamInterface
+                .StreamData($"/{item.Key}", item.Value, DateTime.Now);
                 Thread.Sleep(500);
             }
 

--- a/AstarteDeviceSDKCSharpE2E.Tests/AstarteDeviceTest.cs
+++ b/AstarteDeviceSDKCSharpE2E.Tests/AstarteDeviceTest.cs
@@ -70,11 +70,11 @@ public class AstarteDeviceTest
     /// Test disconnect device from Astarte
     /// </summary>
     [Fact, TestPriority(9)]
-    public void DisconnectDeviceFromAstarte()
+    public async Task DisconnectDeviceFromAstarte()
     {
         Console.WriteLine("Test disconnect device to Astarte");
 
-        astarteDevice.Disconnect();
+        await astarteDevice.Disconnect();
         Assert.False(astarteDevice.IsConnected());
     }
 }

--- a/AstarteDeviceSDKExample/Program.cs
+++ b/AstarteDeviceSDKExample/Program.cs
@@ -151,7 +151,7 @@ namespace AstarteDeviceSDKExample
                 Console.WriteLine("Streaming value: " + value);
 
                 //Stream individual value
-                valuesInterface.StreamData($"/{sensorUuid}/value", value, DateTime.Now);
+                await valuesInterface.StreamData($"/{sensorUuid}/value", value, DateTime.Now);
 
                 Dictionary<string, object> gpsValues = new()
                 {
@@ -161,13 +161,13 @@ namespace AstarteDeviceSDKExample
                     { "accuracy", Random.Shared.NextDouble() },
                     { "altitudeAccuracy", Random.Shared.NextDouble() },
                     { "heading", Random.Shared.NextDouble() },
-                    { "speed", Random.Shared.NextDouble() * 100}
+                    { "speed", Random.Shared.NextDouble() * 100 }
                 };
 
                 Console.WriteLine("Streaming object:" + JsonConvert.SerializeObject(gpsValues));
 
                 //Stream aggregate object
-                aggregateInterface.StreamData($"/{sensorUuid}", gpsValues, DateTime.Now);
+                await aggregateInterface.StreamData($"/{sensorUuid}", gpsValues, DateTime.Now);
 
                 Thread.Sleep(1000);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - Unreleased
 ### Added
+- Add MQTTNet ManagedClient extension version 4.1.4.563.
+- `StreamData` change to `async StreamData` (BREAKING CHANGE!).
+- `Disconnect` change to `async Disconnect` (BREAKING CHANGE!).
 - Add timeout to the `AstartePairingService` constructor.
 - Add device connection timeout to the `ÀstarteDevice` constructor.
 - Update version of MQTTNet libary from 3.1.2 to 4.1.4.563.


### PR DESCRIPTION
Implement extension Managed Client for MQTTNet library. 
Managed Client extension implement package id, strategy for fallout messages sent to MQTT broker.

Added  column guid  in AstarteFailedMessages table, column is type Guid and represent messageId 
Refactor strategy for fallback messages. 
Remove method `HandlePropertiesFailedPublish` and implement interface `IManagedMqttClientStorage`. 
Refactor method for `Connect`, `Disconnect` and `DoSendMqttMessage` to broker with methods from Managed Client. 
Refactor methods to async methods:
- `Disconnect`
- `StreamData` for individual and aggregate messages

Adapt Unit and E2E tests.
Adapt SDK example.
