### PR TITLE
Optimize database locking

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
@@ -24,7 +24,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AstarteDeviceSDKCSharp.Data
 {
-    [Index(nameof(Guid), Name = "Index_Guid")]
+    [Index(nameof(Guid), Name = "Index_Guid", IsUnique = true)]
     public class AstarteFailedMessageEntry : IAstarteFailedMessage
     {
         [Key]

--- a/AstarteDeviceSDKCSharp/Migrations/20240517064719_AddUniqueGuid.Designer.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240517064719_AddUniqueGuid.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstarteDeviceSDKCSharp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AstarteDeviceSDKCSharp.Migrations
 {
     [DbContext(typeof(AstarteDbContext))]
-    partial class AstarteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240517064719_AddUniqueGuid")]
+    partial class AddUniqueGuid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.13");

--- a/AstarteDeviceSDKCSharp/Migrations/20240517064719_AddUniqueGuid.Designer.cs.license
+++ b/AstarteDeviceSDKCSharp/Migrations/20240517064719_AddUniqueGuid.Designer.cs.license
@@ -1,0 +1,5 @@
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/AstarteDeviceSDKCSharp/Migrations/20240517064719_AddUniqueGuid.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240517064719_AddUniqueGuid.cs
@@ -1,0 +1,39 @@
+﻿// This file is part of Astarte.
+//
+// Copyright 2024 SECO Mind Srl
+//
+// SPDX-License-Identifier: Apache-2.0
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AstarteDeviceSDKCSharp.Migrations
+{
+    public partial class AddUniqueGuid : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "Index_Guid",
+                table: "AstarteFailedMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "Index_Guid",
+                table: "AstarteFailedMessages",
+                column: "guid",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "Index_Guid",
+                table: "AstarteFailedMessages");
+
+            migrationBuilder.CreateIndex(
+                name: "Index_Guid",
+                table: "AstarteFailedMessages",
+                column: "guid");
+        }
+    }
+}


### PR DESCRIPTION
Separate locking database operations from locking message list.
Remove message list `stored` and store messages directly into database.
Pick the last message from list in `SaveMessageAsync` method, and store it in database.