### PR TITLE
Resend failed messages in batches

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -22,7 +22,7 @@ using MQTTnet.Extensions.ManagedClient;
 
 namespace AstarteDeviceSDKCSharp.Data
 {
-    public interface IAstarteFailedMessageStorage : IManagedMqttClientStorage
+    public interface IAstarteFailedMessageStorage
     {
         void InsertVolatile(String topic, byte[] payload, int qos, Guid guid);
 
@@ -38,6 +38,10 @@ namespace AstarteDeviceSDKCSharp.Data
 
         bool IsExpired(long expire);
 
-        Task DeleteByGuidAsync(ManagedMqttApplicationMessage applicationMessage);
+        Task DeleteByGuidAsync(Guid applicationMessage);
+
+        Task<IList<ManagedMqttApplicationMessage>> LoadQueuedMessagesAsync();
+        Task SaveQueuedMessageAsync(ManagedMqttApplicationMessage message);
+
     }
 }

--- a/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
+++ b/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
@@ -385,6 +385,7 @@ namespace AstarteDeviceSDKCSharp.Device
             lock (this)
             {
                 _astarteMessagelistener?.OnConnected();
+                _astarteTransport?.StartResenderTask();
             }
         }
 

--- a/AstarteDeviceSDKCSharp/Transport/AstarteTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/AstarteTransport.cs
@@ -90,6 +90,7 @@ namespace AstarteDeviceSDKCSharp.Transport
         public abstract Task Connect();
         public abstract Task Disconnect();
         public abstract bool IsConnected();
+        public abstract void StartResenderTask();
 
         public void SetPropertyStorage(IAstartePropertyStorage propertyStorage)
         {


### PR DESCRIPTION
SDK consumes a large amount of memory after reconnection. It pulls all rows from the database, and there can be a large amount of data.

Removed implementation of ManagedClientStorage to make a custom solution.

This PR resends stored messages in batches (10k messages per batch) due to high memory consumption after reconnecting.

Also, the internal queue of ManagedClient extension is now limited to 10k messages, to prevent high memory consumption due to network latency. If that queue is full, old messages are dropped from the queue, and they will be sent after reconnection.

This PR optimizes LoadQueuedMessagesAsync method for better performance.