### PR TITLE
Optimize message deletion from db

### DIFF
--- a/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
+++ b/AstarteDeviceSDKCSharp/Data/AstarteFailedMessageEntry.cs
@@ -43,6 +43,7 @@ namespace AstarteDeviceSDKCSharp.Data
         [Required]
         [Column("guid")]
         public Guid Guid { get; set; }
+        public bool Processed { get; set; }
 
 
         public AstarteFailedMessageEntry(int qos, byte[] payload, string topic, Guid guid)

--- a/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
+++ b/AstarteDeviceSDKCSharp/Data/IAstarteFailedMessageStorage.cs
@@ -39,6 +39,8 @@ namespace AstarteDeviceSDKCSharp.Data
         bool IsExpired(long expire);
 
         Task DeleteByGuidAsync(Guid applicationMessage);
+        Task MarkAsProcessed(Guid applicationMessage);
+        Task DeleteProcessed();
 
         Task<IList<ManagedMqttApplicationMessage>> LoadQueuedMessagesAsync();
         Task SaveQueuedMessageAsync(ManagedMqttApplicationMessage message);

--- a/AstarteDeviceSDKCSharp/Migrations/20240705081521_AddColumnProcessed.Designer.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240705081521_AddColumnProcessed.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AstarteDeviceSDKCSharp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AstarteDeviceSDKCSharp.Migrations
 {
     [DbContext(typeof(AstarteDbContext))]
-    partial class AstarteDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240705081521_AddColumnProcessed")]
+    partial class AddColumnProcessed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.13");

--- a/AstarteDeviceSDKCSharp/Migrations/20240705081521_AddColumnProcessed.Designer.cs.license
+++ b/AstarteDeviceSDKCSharp/Migrations/20240705081521_AddColumnProcessed.Designer.cs.license
@@ -1,0 +1,5 @@
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/AstarteDeviceSDKCSharp/Migrations/20240705081521_AddColumnProcessed.cs
+++ b/AstarteDeviceSDKCSharp/Migrations/20240705081521_AddColumnProcessed.cs
@@ -1,0 +1,31 @@
+﻿// This file is part of Astarte.
+//
+// Copyright 2024 SECO Mind Srl
+//
+// SPDX-License-Identifier: Apache-2.0
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AstarteDeviceSDKCSharp.Migrations
+{
+    public partial class AddColumnProcessed : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Processed",
+                table: "AstarteFailedMessages",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Processed",
+                table: "AstarteFailedMessages");
+        }
+    }
+}

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
@@ -140,7 +140,14 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
             {
                 if (_failedMessageStorage is not null)
                 {
-                    await _failedMessageStorage.DeleteByGuidAsync(eventArgs.ApplicationMessage.Id);
+                    if (_resendingInProgress)
+                    {
+                        await _failedMessageStorage.MarkAsProcessed(eventArgs.ApplicationMessage.Id);
+                    }
+                    else
+                    {
+                        await _failedMessageStorage.DeleteByGuidAsync(eventArgs.ApplicationMessage.Id);
+                    }
                 }
             }
             else

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttV1Transport.cs
@@ -229,6 +229,10 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                if (!_resendingInProgress)
                {
                    await ResendFailedMessages(cancellationToken);
+                   if (_failedMessageStorage is not null)
+                   {
+                       await _failedMessageStorage.DeleteProcessed();
+                   }
                }
            });
         }


### PR DESCRIPTION
After sending messages to the mqtt broker, every message is deleted from the database.
While resending a large amount of stored messages in 10k batches, deleting is done one by one.

This PR deletes resended messages in one transaction to optimize disk r/w usage. To accomplish that, every processed message is marked in db while resending, and when resending all messages is finished, then we delete all processed messages from db.