### PR TITLE
Order stored messages

### DIFF
--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
@@ -171,7 +171,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
                 .WithAutoReconnectDelay(TimeSpan.FromSeconds(5))
                 .WithMaxPendingMessages(10000)
                 .WithPendingMessagesOverflowStrategy(
-                    MQTTnet.Server.MqttPendingMessagesOverflowStrategy.DropOldestQueuedMessage)
+                    MQTTnet.Server.MqttPendingMessagesOverflowStrategy.DropNewMessage)
                 .Build();
 
             if (!_client.IsStarted)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a fallout strategy for individual failed messages.
 - Resend failed messages stored in the cache memory.
 
+### Fixed
+- Resend stored messages in the order in which they were streamed
+by the user
+
 ## [0.6.0] - 2023-12-18
 ### Added
 - Add the capability to update the introspection dynamically.


### PR DESCRIPTION
When using the persistence mechanism, SDK resends messages to the broker, but not in the order in which they were sent.

Before resending messages from the database, we are waiting for the MQTTNet library to clean its queue, which holds the newest 10k messages sent by user.

This PR drops new messages from the MqttNet library queue to ensure sending stored messages according to how they were streamed by the user. New messages will be sent from the database.