### PR TITLE
Fix certificate renewal

### DIFF
--- a/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
+++ b/AstarteDeviceSDKCSharp/Device/AstarteDevice.cs
@@ -429,6 +429,13 @@ namespace AstarteDeviceSDKCSharp.Device
         public void OnTransportConnectionInitializationError(Exception ex)
         {
             _astarteMessagelistener?.OnFailure(new AstarteMessageException(ex.Message, ex));
+
+            if (!_pairingHandler.IsCertificateAvailable())
+            {
+                _ = _astarteTransport?.Disconnect();
+                _ = Connect();
+            }
+
         }
 
         /// <summary>

--- a/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
+++ b/AstarteDeviceSDKCSharp/Transport/MQTT/AstarteMqttTransport.cs
@@ -193,10 +193,7 @@ namespace AstarteDeviceSDKCSharp.Transport.MQTT
         {
             if (_client != null)
             {
-                if (_client.IsConnected)
-                {
-                    await _client.StopAsync();
-                }
+                await _client.StopAsync();
             }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resend stored messages in the order in which they were streamed
 by the user
+- Regenerate client certificate after expiration
 
 ## [0.6.0] - 2023-12-18
 ### Added


### PR DESCRIPTION
If the client certificate is expired after disconnection, SDK is not able to generate a new one.

Using the `OnConnectingFailAsync` event, we are checking if the certificate is expired. When a new certificate is generated, we need to stop (not only disconnect) the MQTT client and start it again, so the MQTTNet library loads the new certificate.