### PR TITLE
Update timeout time for http/s requests to Astarte

### DIFF
--- a/AstarteDeviceSDKCSharpE2E.Tests/Utilities/AstarteDeviceSingleton.cs
+++ b/AstarteDeviceSDKCSharpE2E.Tests/Utilities/AstarteDeviceSingleton.cs
@@ -62,7 +62,7 @@ namespace AstarteDeviceSDKCSharpE2E.Tests.Utilities
                         new MockInterfaceProvider(),
                         astarteMockData.PairingUrl,
                         cryptoStoreDir,
-                        TimeSpan.FromMilliseconds(500),
+                        TimeSpan.FromMilliseconds(5000),
                         true
                     );
                     astarteDevice.SetAlwaysReconnect(true);


### PR DESCRIPTION
A possible reason for the E2E pipeline crashing is a timeout on an HTTP request to Astarte. This is a WIP PR for testing.

Update timeout time for http/s requests to Astarte from 500 milliseconds to 5 seconds.