### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,13 +42,13 @@ jobs:
       run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       
     - name: Build
-      run: dotnet build -c Release /p:Version=${VERSION}
+      run: dotnet build AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj -c Release /p:Version=${VERSION}
       
     - name: Test
-      run: dotnet test -c Release /p:Version=${VERSION} --no-build
+      run: dotnet test AstarteDeviceSDKCSharp.Tests/AstarteDeviceSDKCSharp.Tests.csproj -c Release /p:Version=${VERSION}
       
     - name: Pack nugets
-      run: dotnet pack -c Release /p:Version=${VERSION} --no-build --output .
+      run: dotnet pack AstarteDeviceSDKCSharp/AstarteDeviceSDKCSharp.csproj -c Release /p:Version=${VERSION} --no-build --output .
       
     - name: Push to NuGet
-      run: dotnet nuget push "*.nupkg" --api-key ${{secrets.nuget_api_key}} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Release workflow fails on running tests. It runs E2E tests which are not configured in release.yaml workflow.
This PR runs only unit tests before publishing on Nuget.
Build command changed to build only SDK.