### PR TITLE
Implement allow unest mapping

### DIFF
--- a/AstarteDeviceSDKCSharp/Protocol/AstarteDevicePropertyInterface.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteDevicePropertyInterface.cs
@@ -84,15 +84,25 @@ namespace AstarteDeviceSDKCSharp.Protocol
                 throw new AstarteTransportException("No available transport");
             }
 
-            transport.SendIndividualValue(this, path, null);
+            bool allowUnset = this.FindMappingInInterface(path).AllowUnset;
 
-            try
+            if (allowUnset)
             {
-                propertyStorage.RemoveStoredPath(GetInterfaceName(), path, GetMajorVersion());
+                transport.SendIndividualValue(this, path, null);
+
+                try
+                {
+                    propertyStorage.RemoveStoredPath(GetInterfaceName(), path, GetMajorVersion());
+                }
+                catch (AstartePropertyStorageException e)
+                {
+                    throw new AstarteTransportException("Property storage failure", e);
+                }
             }
-            catch (AstartePropertyStorageException e)
+            else
             {
-                throw new AstarteTransportException("Property storage failure", e);
+                throw new AstarteInvalidValueException(
+                    $"Unset operation not allowed for path {path}");
             }
         }
     }

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceMapping.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceMapping.cs
@@ -27,6 +27,7 @@ namespace AstarteDeviceSDK.Protocol
         public string? Path { get; set; }
         public Type? MapType { get; set; }
         public Type? PrimitiveArrayType { get; set; }
+        public bool AllowUnset { get; set; } = false;
 
         public static AstarteInterfaceMapping FromAstarteInterfaceMapping(Mapping astarteMapping)
         {
@@ -40,6 +41,7 @@ namespace AstarteDeviceSDK.Protocol
             Path = astarteMappingObject.Endpoint;
             MapType = StringToCSharpType(astarteMappingObject.Type);
             PrimitiveArrayType = StringToPrimitiveArrayCSharpType(astarteMappingObject.Type);
+            AllowUnset = astarteMappingObject.AllowUnset;
         }
 
         public string? GetPath()

--- a/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceModel.cs
+++ b/AstarteDeviceSDKCSharp/Protocol/AstarteInterfaceModel.cs
@@ -73,5 +73,8 @@ namespace AstarteDeviceSDK.Protocol
         [JsonProperty("expiry")]
         public int? Expiry { get; set; }
 
+        [JsonProperty("allow_unset")]
+        public bool AllowUnset { get; set; } = false;
+
     }
 }

--- a/AstarteDeviceSDKExample/Resources/standard-interfaces/org.astarte-platform.genericsensors.AvailableSensors.json
+++ b/AstarteDeviceSDKExample/Resources/standard-interfaces/org.astarte-platform.genericsensors.AvailableSensors.json
@@ -11,12 +11,14 @@
             "endpoint": "/%{sensor_id}/name",
             "type": "string",
             "description": "Sensor name.",
+            "allow_unset": true,
             "doc": "An arbitrary sensor name."
         },
         {
             "endpoint": "/%{sensor_id}/unit",
             "type": "string",
             "description": "Sample data measurement unit.",
+            "allow_unset": true,
             "doc": "SI unit such as m, kg, K, etc..."
         }
     ]


### PR DESCRIPTION
Add support for the existing allow_unset field in Astarte interface mappings by implementing its actual runtime behaviour. When allow_unset is set to true, the SDK now permits `UnsetProperty` a property. When it is false (or omitted), `UnsetProperty` the property throws an exception.


- Implemented enforcement of the allow_unset flag in AstarteDevicePropertyInterface.UnsetProperty.
- If allow_unset == true → unsetting is allowed
- If allow_unset == false or the field is missing → throw AstarteInvalidValueException.
- Ensured that existing mapping structures correctly pass the allow_unset value to runtime logic.
- Updated example interface JSON to show how "allow_unset": true enables unsetting.